### PR TITLE
Integration with hash extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ It will checksum the string, and return the checksum.
 
 ## `hash()` integration
 
-It also registers the hash algorithm to be used in the `hash()` functions:
+It also registers the `xx32` hash algorithm to be used in the [`hash()`](http://www.php.net/manual/en/ref.hash.php) function family:
 
 ```
-    hash('xx', $data);
+    hash('xx32', $data);
 
 Or:
 
-    $h = hash_init('xx');
+    $h = hash_init('xx32');
     hash_update($h, $data);
     echo hash_final($h);
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ This extension adds one new PHP function:
 
 It will checksum the string, and return the checksum.
 
+## `hash()` integration
+
+It also registers the hash algorithm to be used in the `hash()` functions:
+
+```
+    hash('xx', $data);
+
+Or:
+
+    $h = hash_init('xx');
+    hash_update($h, $data);
+    echo hash_final($h);
+```
+
 ## License
 
 BSD 2-clause license.


### PR DESCRIPTION
I've added a few functions to integrate `xxhash32` into PHP's hash functions, so that you can use `hash_init()`, `hash_update()` and `hash_final()` amongst others :-)
